### PR TITLE
use AsRef<[u8]> instead of &[u8]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yaw = { git = "https://github.com/bokuweb/yaw.git" }
 use yaw::*;
 
 fn main() -> Result<(), error::YawError> {
-    let ins = instantiate(&include_bytes!("./add.wasm")[..], None)?;
+    let ins = instantiate(&include_bytes!("./add.wasm"), None)?;
     let ret = ins.invoke("add", &[RuntimeValue::I32(1), RuntimeValue::I32(2)])?;
     println!("1 + 2 = {:?}", ret);
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,12 @@ pub use vm::{
     MemoryRef, RuntimeError, TableInstance, TableRef, VM,
 };
 
-pub fn instantiate<'a>(
-    buf: &[u8],
+pub fn instantiate<'a, B: AsRef<[u8]>>(
+    buf: B,
     imports: Option<&'a dyn ImportResolver>,
 ) -> Result<VM<'a>, error::YawError> {
     let mut magic_number = [0; 4];
-    let mut reader = &buf[..];
+    let mut reader = buf.as_ref();
     reader.read_exact(&mut magic_number)?;
     let magic_number = String::from_utf8(magic_number.to_vec())?;
     if magic_number != "\0asm" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,10 @@ pub use vm::{
     MemoryRef, RuntimeError, TableInstance, TableRef, VM,
 };
 
-pub fn instantiate<'a, B: AsRef<[u8]>>(
+pub fn instantiate<B: AsRef<[u8]>>(
     buf: B,
-    imports: Option<&'a dyn ImportResolver>,
-) -> Result<VM<'a>, error::YawError> {
+    imports: Option<&dyn ImportResolver>,
+) -> Result<VM<'_>, error::YawError> {
     let mut magic_number = [0; 4];
     let mut reader = buf.as_ref();
     reader.read_exact(&mut magic_number)?;


### PR DESCRIPTION
Currently `instantiate()` only accepts exact u8 slice. It is not very useful when `u8` array is passed. I modified to accept any type which implements `AsRef<[u8]>`.